### PR TITLE
Use ActiveMQ to send data from collector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source 'https://rubygems.org'
 gem "trollop"
 gem "rbvmomi"
 gem "ruby-kafka"
+gem "stomp"
 gem "manageiq-providers-inventory", :git => "https://github.com/agrare/manageiq-providers-inventory"

--- a/manageiq/providers/vmware/active_mq_client.rb
+++ b/manageiq/providers/vmware/active_mq_client.rb
@@ -1,0 +1,12 @@
+require 'stomp'
+
+class ManageIQ::Providers::Vmware::ActiveMqClient < Stomp::Client
+  def self.open(long_live = false, client_id = nil)
+    hosts = [{:login => "admin", :passcode => "smartvm", :host => "127.0.0.1", :port => 61613}]
+    headers = {}
+    headers.merge!(:host => "127.0.0.1", :"accept-version" => "1.2", :"heart-beat" => "2000,2000") if long_live
+    headers.merge!(:"client-id" => client_id) if client_id
+
+    super(:hosts => hosts, :connect_headers => headers)
+  end
+end

--- a/manageiq/providers/vmware/collector.rb
+++ b/manageiq/providers/vmware/collector.rb
@@ -2,6 +2,7 @@ require 'kafka'
 require 'yaml'
 require 'rbvmomi/vim'
 require 'manageiq/providers/vmware/parser'
+require 'manageiq/providers/vmware/miq_queue'
 require 'manageiq/providers/vmware/collector/connection'
 require 'manageiq/providers/vmware/collector/property_collector'
 
@@ -36,8 +37,9 @@ module ManageIQ
         end
 
         def publish_inventory(stream, inventory)
-          stream.produce(inventory, topic: "inventory")
-          stream.deliver_messages
+          ManageIQ::Providers::Vmware::MiqQueue.put_job(:message => inventory, :service => 'ems_operation')
+          #stream.produce(inventory, topic: "inventory")
+          #stream.deliver_messages
         end
 
         def wait_for_updates(vim)

--- a/manageiq/providers/vmware/miq_queue.rb
+++ b/manageiq/providers/vmware/miq_queue.rb
@@ -1,0 +1,48 @@
+require 'manageiq/providers/vmware/active_mq_client'
+
+class ManageIQ::Providers::Vmware::MiqQueue
+  # options:
+  #   :message
+  #   :sender (optional)
+  #   :message_type (optional)
+  #   :service
+  #   :resource (optional)
+  #   :other keys same as put_background_job
+  def self.put_job(client = nil, options)
+    assert_options(options, [:message, :service])
+
+    options = options.dup
+    address, headers = queue_for_publish(options)
+    headers[:sender] = options.delete(:sender) if options[:sender]
+    headers[:message_type] = options.delete(:message_type) if options[:message_type]
+
+    unless client
+      client = ManageIQ::Providers::Vmware::ActiveMqClient.open
+      close_on_exit = true
+    end
+    client.publish(address, options[:message].to_yaml, headers)
+    pp("Address(#{address}), msg(#{options[:message].inspect}), headers(#{headers.inspect})")
+    client.close if close_on_exit
+  end
+
+  def self.queue_for_publish(options)
+    resource = options.delete(:resource) || 'none'
+    address = "queue/#{options.delete(:service)}.#{resource}"
+
+    headers = {:"destination-type" => "ANYCAST"}
+    headers[:expires] = options.delete(:expires_on).to_i * 1000 if options[:expires_on]
+    headers[:AMQ_SCHEDULED_TIME] = options.delete(:deliver_on).to_i * 1000 if options[:deliver_on]
+    headers[:priority] = options.delete(:priority) if options[:priority]
+
+    [address, headers]
+  end
+  private_class_method :queue_for_publish
+
+  def self.assert_options(options, keys)
+    keys.each do |key|
+      raise "options must contains key #{key}" if options[key].nil?
+    end
+  end
+  private_class_method :assert_options
+
+end

--- a/manageiq/providers/vmware/parser.rb
+++ b/manageiq/providers/vmware/parser.rb
@@ -28,11 +28,11 @@ module ManageIQ
             }
           end.compact
 
-          inv = YAML.dump({
+          inv = {
             :ems_id      => @ems_id,
             :class       => "ManageIQ::Providers::Vmware::InfraManager::Inventory::Persister::Stream",
             :collections => collections
-          })
+          }
         end
 
         def parse_compute_resource(cluster, props)


### PR DESCRIPTION
This is the prototype to use ActiveMQ to send data from collector to persister. 
We'd better to extract `MiqQueue` to a separate gem so it can be used by any components that may not have a dependency on core manageiq. 